### PR TITLE
feat: add `NixCmd::run_with_args`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "nix_rs"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "bytesize",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix_rs"
 # Important: remember to update the top-level Cargo.toml if updating major version
-version = "0.3.3"
+version = "0.4.0"
 license = "Apache-2.0"
 repository = "https://github.com/juspay/nix-rs"
 description = "Rust library for interacting with the Nix command"

--- a/src/flake/eval.rs
+++ b/src/flake/eval.rs
@@ -30,7 +30,12 @@ where
 fn error_is_missing_attribute(err: &NixCmdError) -> bool {
     match err {
         NixCmdError::CmdError(CommandError::ProcessFailed { stderr, .. }) => {
-            stderr.contains("does not provide attribute")
+            if let Some(stderr) = stderr {
+                if stderr.contains("does not provide attribute") {
+                    return true;
+                }
+            }
+            false
         }
         _ => false,
     }


### PR DESCRIPTION
Useful to run Nix whilst streaming stdout/stderr to parent process's output.

This introduces backwards incompatible change to the error type's `ProcessFailed` constructor.